### PR TITLE
Remove deps from doc CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: rustfmt
         run: cargo fmt --all -- --check
       - name: docs
-        run: cargo doc
+        run: cargo doc --no-deps
 
   build_and_test:
     name: Build & Test


### PR DESCRIPTION
Building docs with deps is always an option if they need to be personally reviewed, but they introduce noise in CI.