### PR TITLE
Set up cross-license collaborative terms and licenses

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -27,6 +27,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "felipesere",
+      "name": "Felipe Seré",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1850188?v=4",
+      "profile": "https://github.com/felipesere",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,24 @@
+{
+  "projectName": "orogene",
+  "projectOwner": "orogene",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "zkat",
+      "name": "Kat Marchán",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/17535?v=4",
+      "profile": "https://github.com/zkat",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4,7 +4,7 @@
   "repoType": "github",
   "repoHost": "https://github.com",
   "files": [
-    "README.md"
+    "MEMBERS.md"
   ],
   "imageSize": 100,
   "commit": true,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "chrisdickinson",
+      "name": "Chris Dickinson",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/37303?v=4",
+      "profile": "https://www.neversaw.us/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/CROSS_LICENSE.md
+++ b/CROSS_LICENSE.md
@@ -1,0 +1,211 @@
+# Cross-License Collaborative Agreement
+
+Version 1.0.0-pre.5
+
+## Purpose
+
+These terms enable contributors working together on a project covered by copyrights or patents to make collective decisions about licensing their project as a whole.
+
+## Acceptance
+
+In order to get any license under these terms, you must apply to become a contributor, be accepted, and agree to these terms. These terms are both strict obligations under an agreement among all contributors and conditions to all the cross-licenses they give and receive under that agreement.
+
+## Contributors
+
+### Qualifications
+
+Only candidates offering contributions of copyrights or patent rights to the project can apply to become contributors.
+
+### Application
+
+To apply to become a contributor, a candidate must provide the following to an existing contributor:
+
+1.  their [address](#addresses) for [communication](#communications)
+
+2.  their [instructions](#payment-instructions) for [payment](#payments)
+
+3.  a World Wide Web or other Internet address where contributors can review the contribution they are offering
+
+### Admission
+
+For a candidate to become a contributor, an existing contributor must follow each of these steps, one after another, in order:
+
+1.  [circulate](#circulating-messages) the candidate's complete application
+
+2.  secure [majority approval](#majority) in favor of their application
+
+3.  provide the candidate complete copies of all sublicenses still in effect
+
+4.  receive and [circulate](#circulating-messages) a message from the candidate confirming receipt of, and approving, all sublicenses still in effect
+
+5.  [circulate](#circulating-messages) a current list of all contributor [addresses](#addresses) and [payment instructions](#payment-instructions), including the new contributor's
+
+### Resignation
+
+Any contributor may resign at any time by [circulating](#circulating-messages) a message of resignation. When a contributor resigns, all cross-licenses to that contributor end, but their cross-licenses to other contributors, as well as any sublicenses they have given, continue.
+
+## Cross-Licenses
+
+### Copyright
+
+Each contributor gives a cross-license covering all copyrights in their contributions to the project to each other contributor.
+
+### Patent
+
+Each contributor gives a cross-license for the project covering any patent claims they can license or become able to license to each other contributor.
+
+### Scope
+
+Each cross-license under these terms covers all contributors, past, present, and future, and all contributions submitted to the project, past, present, and future.
+
+### Rights
+
+Cross-licenses under these terms do not give contributors themselves any special permission for the project, only permission to give sublicenses to others.
+
+### Sublicensing
+
+Any contributor may give a sublicense within thirty calendar days of securing [majority approval](#majority). When [soliciting votes](#soliciting-votes) for a sublicense, a contributor must [circulate](#circulating-messages):
+
+1.  identification of the contributor proposing to give the sublicense
+
+2.  an exact copy of all the proposed sublicense terms
+
+3.  identification of the recipient or recipients of the sublicense
+
+4.  a description of any relationship between those who will receive or benefit from the sublicense
+
+5.  an exact copy of all the terms of any agreement that has, will, or could pay the contributor proposing to give the sublicense for proposing or securing approval for the sublicense
+
+Contributors may give sublicenses to specific recipients, categories of recipients, or the public as a whole. Sublicenses may allow sublicensing in turn. Sublicenses must apply from the time the sublicense is given, or from a time stated in the terms, not retroactively.
+
+## Communications
+
+### Equal Information
+
+Each contributor is entitled to receive each message sent to any other contributor under these terms.
+
+### Circulating Messages
+
+To circulate a message under these terms, a contributor must send the message in the English language to each other contributor, [retrying](#retry) as necessary.
+
+### Circulating Notices
+
+Any contributor who receives a notice under the terms of a sublicense must [circulate](#circulating-messages) that notice, [retrying](#retrying) as necessary.
+
+### Addresses
+
+The first two contributors must agree on a global, free or low-cost, high-speed, electronic communication system, such as e-mail, and provide addresses for that system. Later contributors must provide addresses for the same system.
+
+### Change of Address
+
+Any contributor may change their address by [circulating](#circulating-messages) their new address from their current address. Alternatively, any contributor may change their address by [circulating](#circulating-messages) their new address from a different address and securing [supermajority approval](#supermajority), without any opposing message from their old address.
+
+## Voting
+
+### Equal Vote
+
+Each contributor is entitled to cast a single, equal vote on each proposal under these terms.
+
+### Majority
+
+For majority approval, a majority of responding contributors must vote in favor.
+
+### Supermajority
+
+For supermajority approval, two thirds of responding contributors must vote in favor.
+
+### Counting
+
+The contributor soliciting approval counts as a contributor voting in favor.
+
+### Deadline
+
+The deadline for approval of any proposal is thirty calendar days from when [votes were first solicited](#soliciting-votes).
+
+### Securing Approval
+
+To secure an approval, a contributor must [solicit votes](#soliciting-votes), then [tally votes](#tallying-votes), and finally [report the result](#reporting-results).
+
+### Soliciting Votes
+
+To solicit votes, a contributor must [circulate](#circulating-messages) a single message with all of these details:
+
+1.  the identity of the project
+
+2.  the complete text of the proposal
+
+3.  the voting standard required
+
+4.  the date of the [deadline](#deadline)
+
+### Casting Votes
+
+Contributors may vote by replying to a message soliciting votes using the same communication system. Messages like "I approve.", "I vote in favor.", and "Aye" count as votes in favor. Messages like "I oppose.", "I vote against.", and "Nay" count as votes against.
+
+### Tallying Votes
+
+To tally votes, the contributor who solicited votes must ensure that each vote message is [circulated](#circulating-messages). If the communication system enables forwarding messages verbatim, such as by forwarding e-mail, the contributor must forward vote messages verbatim. If a voting contributor [circulates](#circulating-messages) their vote themself, the contributor soliciting votes need not [circulate](#circulating-messages) it again.
+
+### Reporting Results
+
+To report a result, the contributor who solicited votes must [circulate](#circulating-messages) a single message with all of these details within seven calendar days after the [deadline](#deadline):
+
+1.  all the information required to [solicit votes](#soliciting-votes)
+
+2.  copies of all [vote messages](#voting)
+
+3.  counts of votes in favor, votes against, and contributors not responding by the [deadline](#deadline)
+
+4.  whether contributors approved the proposal or not
+
+## Payments
+
+### Equal Pay
+
+Each contributor is entitled to receive an equal share of license fees, license royalties, and other license-based payments for the project. Any sublicense that entitles any contributor to payment must require payment to the contributor who gave the sublicense to start, and to any successor for which any contributor secures [majority approval](#majority) after.
+
+### Distributing Payments
+
+Any contributor who receives payment under a sublicense must pay other contributors their [equal shares](#equal-pay) of funds received within fourteen calendar days, according to their [payment instructions](#payment-instructions), [retrying](#retry) as necessary.
+
+### Payment Processing Fees
+
+If a contributor's [payment instructions](#payment-instructions) require the distributing contributor to pay a fee, the contributor making the payment may reduce the amount of the payment by the amount of the fee, so the distributing contributor does not have to pay any processing fees out of pocket.
+
+### Failed Payments
+
+If a contributor does not respond to a payment of their share, the next step depends on the amount of their share.
+
+If the amount is ten percent or less of the payment under the sublicense, or the payment processing fees would be 50% or more of the amount, then the distributing contributor may keep the amount for themself.
+
+Otherwise, the distributing contributor must try to pay themself and other contributors, but not the contributor that is not responding, equal shares of the amount, according to their [payment instructions](#payment-instructions). If those payments fail, the distributing contributor does not have to [retry](#retry) them, but can keep the amounts for themself.
+
+### Payment Instructions
+
+Contributors must provide payment instructions for global, low-cost, high-speed, electronic payment systems.
+
+### Change of Payment Instructions
+
+Any contributor may change their [payment instructions](#payment-instructions) by [circulating](#circulating-messages) new [payment instructions](#payment-instructions) from their current [address](#addresses).
+
+## Retry
+
+When a [communication](#communications) or [payment](#payments) system fails to deliver a message or payment:
+
+1.  The sending contributor must [circulate](#circulating-messages) word of the failure and any failure message from the system.
+
+2.  The sending contributor must wait 48 hours, then try again. If the receiving contributor [changed](#change-of-address) their [address](#address) or [changed](#change-of-payment-instructions) their [payment instructions](#payment-instructions) since the first try, the sending contributor must use the new [address](#address) or [payment instructions](#payment-instructions).
+
+3.  If the second try also fails, the sending contributor must [circulate](#circulating-messages) word of the failure and any failure message from the system. The receiving contributor is then considered to be not responding.
+
+## Broken Rules
+
+If any contributor unintentionally breaks a rule of these terms at the expense of another contributor, and the contributor who was wronged [circulates](#circulating-messages) a message about the breach, other contributors can keep their cross-licenses from the contributor who was wronged if any one or more of them makes the situation right within fourteen calendar days. If the contributor did not get an [equal vote](#equal-vote), contributors must retake the vote. If the contributor did not get [equal pay](#equal-pay), contributors must pay what was owed, and if the payment is thirty days or more late, interest at the base rate for the national bank of the country where the contributor lives, compounded monthly. If the contributor did not get [equal information](#equal-information), contributors must [circulate](#cirulating-messages) the message again, and if any vote was taken between when the message was not sent and when the contributor finally received it, contributors must retake that vote.
+
+## Changes
+
+Any contributor may change these terms by securing [supermajority approval](#supermajority) in favor of the change. Changes apply from the time of approval going forward, not retroactively.
+
+## No Liability
+
+**_As far as the law allows, the project comes as is, without any warranty or condition, and no contributor will be liable to any other contributor for any damages related to the project or these terms, under any kind of legal claim._**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "orogene"
 version = "0.1.0"
-authors = ["Kat Marchán <kzm@zkat.tech>"]
+authors = ["Orogene Collaborative Members", "Orogene Public Contributors"]
 edition = "2018"
 description = "wip"
-license = "Proprietary"
+license-file = "LICENSE.md"
+repository = "https://github.com/orogene/orogene"
+homepage = "https://github.com/orogene/orogene"
+readme = "README.md"
 build = "build.rs"
 
 [workspace]

--- a/LICENSE-APACHE.md
+++ b/LICENSE-APACHE.md
@@ -1,0 +1,13 @@
+Copyright 2020 Orogene Open Source Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-PARITY.md
+++ b/LICENSE-PARITY.md
@@ -1,0 +1,71 @@
+# The Parity Public License 7.0.0
+
+Contributors: See [MEMBERS.md](MEMBERS.md)
+
+Source Code: https://github.com/orogene/orogene
+
+## Purpose
+
+This license allows you to use and share this software for free, but you have to share software that builds on it alike.
+
+## Agreement
+
+In order to receive this license, you have to agree to its rules. Those rules are both obligations under that agreement and conditions to your license. Don't do anything with this software that triggers a rule you can't or won't follow.
+
+## Notices
+
+Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.
+
+## Copyleft
+
+[Contribute](#contribute) software you develop, operate, or analyze with this software, including changes or additions to this software. When in doubt, [contribute](#contribute).
+
+## Prototypes
+
+You don't have to [contribute](#contribute) any change, addition, or other software that meets all these criteria:
+
+1.  You don't use it for more than thirty days.
+
+2.  You don't share it outside the team developing it, other than for non-production user testing.
+
+3.  You don't develop, operate, or analyze other software with it for anyone outside the team developing it.
+
+## Reverse Engineering
+
+You may use this software to operate and analyze software you can't [contribute](#contribute) in order to develop alternatives you can and do [contribute](#contribute).
+
+## Contribute
+
+To [contribute](#contribute) software:
+
+1.  Publish all source code for the software in the preferred form for making changes through a freely accessible distribution system widely used for similar source code so the contributor and others can find and copy it.
+
+2.  Make sure every part of the source code is available under this license or another license that allows everything this license does, such as [the Blue Oak Model License 1.0.0](https://blueoakcouncil.org/license/1.0.0), [the Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0.html), [the MIT license](https://spdx.org/licenses/MIT.html), or [the two-clause BSD license](https://spdx.org/licenses/BSD-2-Clause.html).
+
+3.  Take these steps within thirty days.
+
+4.  Note that this license does _not_ allow you to change the license terms for this software. You must follow [Notices](#notices).
+
+## Excuse
+
+You're excused for unknowingly breaking [Copyleft](#copyleft) if you [contribute](#contribute) as required, or stop doing anything requiring this license, within thirty days of learning you broke the rule. You're excused for unknowingly breaking [Notices](#notices) if you take all practical steps to comply within thirty days of learning you broke the rule.
+
+## Defense
+
+Don't make any legal claim against anyone accusing this software, with or without changes, alone or with other technology, of infringing any patent.
+
+## Copyright
+
+The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
+
+## Patent
+
+The contributor licenses you to do everything with this software that would otherwise infringe any patents they can license or become able to license.
+
+## Reliability
+
+The contributor can't revoke this license.
+
+## No Liability
+
+**_As far as the law allows, this software comes as is, without any warranty or condition, and the contributor won't be liable to anyone for any damages related to this software or this license, under any kind of legal claim._**

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,10 @@
+## License
+
+Licensing decisions are controlled by [Cross-License Collaborative
+Members](#members), as defined in the [cross-licensing
+terms](CROSS_LICENSE.md).
+
+All contributions by Members are licensed under [the Parity
+License](LICENSE_PARITY.md). Non-member contributions are licensed under
+[Apache 2.0](LICENSE_APACHE.md).
+

--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -1,0 +1,17 @@
+## Members ✨
+
+The following are the official project members of the collaborative. ([emoji
+key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/zkat"><img src="https://avatars1.githubusercontent.com/u/17535?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kat Marchán</b></sub></a><br /><a href="https://github.com/orogene/orogene/commits?author=zkat" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -9,6 +9,7 @@ key](https://allcontributors.org/docs/en/emoji-key)):
 <table>
   <tr>
     <td align="center"><a href="https://github.com/zkat"><img src="https://avatars1.githubusercontent.com/u/17535?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kat Marchán</b></sub></a><br /><a href="https://github.com/orogene/orogene/commits?author=zkat" title="Code">💻</a></td>
+    <td align="center"><a href="https://www.neversaw.us/"><img src="https://avatars3.githubusercontent.com/u/37303?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Dickinson</b></sub></a><br /><a href="https://github.com/orogene/orogene/commits?author=chrisdickinson" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -10,6 +10,7 @@ key](https://allcontributors.org/docs/en/emoji-key)):
   <tr>
     <td align="center"><a href="https://github.com/zkat"><img src="https://avatars1.githubusercontent.com/u/17535?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kat Marchán</b></sub></a><br /><a href="https://github.com/orogene/orogene/commits?author=zkat" title="Code">💻</a></td>
     <td align="center"><a href="https://www.neversaw.us/"><img src="https://avatars3.githubusercontent.com/u/37303?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Dickinson</b></sub></a><br /><a href="https://github.com/orogene/orogene/commits?author=chrisdickinson" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/felipesere"><img src="https://avatars0.githubusercontent.com/u/1850188?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Felipe Seré</b></sub></a><br /><a href="https://github.com/orogene/orogene/commits?author=felipesere" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -1,6 +1,6 @@
 ## Members ✨
 
-The following are the official project members of the collaborative. ([emoji
+The following are the official project members of the [Collaborative](CROSS_LICENSE.md). ([emoji
 key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # orogene ![CI](https://github.com/orogene/orogene/workflows/CI/badge.svg)
 
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
 Manage your NPM packages.
+
+## License
+
+Licensing decisions are controlled by [Cross-License Collaborative Members](MEMBERS.md), as
+defined in the [cross-licensing terms](CROSS_LICENSE.md).
+
+## Members ✨
+
+The following are the official project members of the collaborative. ([emoji
+key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/zkat"><img src="https://avatars1.githubusercontent.com/u/17535?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kat Marchán</b></sub></a><br /><a href="https://github.com/orogene/orogene/commits?author=zkat" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -1,30 +1,12 @@
 # orogene ![CI](https://github.com/orogene/orogene/workflows/CI/badge.svg)
 
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-
-Manage your NPM packages.
+Yet another JavaScript package manager, I guess.
 
 ## License
 
-Licensing decisions are controlled by [Cross-License Collaborative Members](MEMBERS.md), as
+Licensing decisions are controlled by [Cross-License Collaborative Members](#members), as
 defined in the [cross-licensing terms](CROSS_LICENSE.md).
 
-## Members ✨
-
-The following are the official project members of the collaborative. ([emoji
-key](https://allcontributors.org/docs/en/emoji-key)):
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tr>
-    <td align="center"><a href="https://github.com/zkat"><img src="https://avatars1.githubusercontent.com/u/17535?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kat Marchán</b></sub></a><br /><a href="https://github.com/orogene/orogene/commits?author=zkat" title="Code">💻</a></td>
-  </tr>
-</table>
-
-<!-- markdownlint-enable -->
-<!-- prettier-ignore-end -->
-<!-- ALL-CONTRIBUTORS-LIST:END -->
+All contributions by Members are licensed under [the Parity
+License](LICENSE_PARITY.md). Non-member contributions are licensed under
+[Apache 2.0](LICENSE_APACHE.md).


### PR DESCRIPTION
As it says on the tin -- these are the terms under which I'd like to license Orogene. For the time being, there's no way to actually _sell_ proprietary-use licenses, but we can get there later, probably through OpenCollective/GH Sponsors for Orgs.

I'd like to make sure @chrisdickinson and @felipesere, who are the ones who have contributed non-trivial patches so far, agree to these terms.

Feel free to ask any questions you have about these terms! I am not a lawyer, but I'll try and answer in my limited capacity!

## Summary

1. Added `CROSS_LICENSE.md`, which is from https://xlcollaborative.com. This sets the cross-licensing terms we'll use to grant each other license-granting licenses (so meta!)
2. Added `MEMBERS.md`, which will be the official list of Collab Members.
3. Added `LICENSE-PARITY.md`, which pulls in the [Parity License](https://paritylicense.com/versions/7.0.0). All Collab Members agree to license their contributions under this license. The tl;dr of this license is "Free for Open Source", in general terms, though with some caveats. The idea is that anyone can use orogene as long as the project they're working on is under an open source license (that is "at least as permissive" as Parity). If they want to work on private or work projects, they have to stop using it after a certain amount of time. The way around this is to buy proprietary licenses (which we might do _eventually_, but this PR does not set up. That will be a separate, future discussion).
4. Added `LICENSE-APACHE.md`, which pulls in plain old Apache-2.0. This is the license that non-Member contributions will be licensed under.
5. Added `LICENSE.md` which just points people to the other two licenses.
6. Added an All Contributors rc file so we can maintain the `MEMBERS.md` file more easily.