### PR TITLE
Argument parsing for the shell command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmd-shell"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap 3.0.0-beta.1",
+ "log",
+ "oro-command",
+ "oro-config",
+ "oro-error-code",
+]
+
+[[package]]
 name = "cmd-view"
 version = "0.1.0"
 dependencies = [
@@ -1838,6 +1851,7 @@ dependencies = [
  "clap 3.0.0-beta.1",
  "cmd-ping",
  "cmd-restore",
+ "cmd-shell",
  "cmd-view",
  "embed-resource",
  "fern",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default-members = [".", "crates/*", "commands/*"]
 cmd-ping = { path = "./commands/cmd-ping" }
 cmd-restore = { path = "./commands/cmd-restore" }
 cmd-view = { path = "./commands/cmd-view" }
+cmd-shell = { path = "./commands/cmd-shell" }
 
 # Workspace Deps
 oro-client = { path = "./crates/oro-client" }

--- a/commands/cmd-shell/Cargo.toml
+++ b/commands/cmd-shell/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cmd-shell"
+version = "0.1.0"
+authors = ["Felipe Sere <felipesere@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+oro-command = { path = "../../crates/oro-command" }
+oro-config = { path = "../../crates/oro-config" }
+oro-error-code = { path = "../../crates/oro-error-code" }
+clap = { git = "https://github.com/zkat/clap" }
+
+anyhow = "1.0.25"
+async-trait = "0.1.19"
+log = "0.4.11"

--- a/commands/cmd-shell/src/lib.rs
+++ b/commands/cmd-shell/src/lib.rs
@@ -1,0 +1,63 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use clap::{ArgMatches, Clap};
+use oro_command::OroCommand;
+use oro_command::OroCommandLayerConfig;
+use oro_config::OroConfig;
+use oro_error_code::OroErrCode as Code;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+#[derive(Debug, Clap)]
+pub struct ShellCmd {
+    #[clap(long, default_value = "node")]
+    node: String,
+
+    #[clap(long)]
+    data_dir: Option<PathBuf>,
+
+    #[clap(multiple = true)]
+    args: Vec<String>,
+
+    #[clap(from_global)]
+    loglevel: log::LevelFilter,
+    #[clap(from_global)]
+    json: bool,
+    #[clap(from_global)]
+    quiet: bool,
+}
+
+#[async_trait]
+impl OroCommand for ShellCmd {
+    async fn execute(self) -> Result<()> {
+        dbg!(&self);
+        Ok(())
+    }
+}
+
+impl OroCommandLayerConfig for ShellCmd {
+    fn layer_config(&mut self, args: ArgMatches, config: OroConfig) -> Result<()> {
+        if args.occurrences_of("node") == 0 {
+            if let Ok(val) = config.get_str("node") {
+                self.node = String::from_str(&val)?;
+            }
+        }
+        if args.occurrences_of("json") == 0 {
+            if let Ok(val) = config.get_bool("json") {
+                self.json = val;
+            }
+        }
+        if args.occurrences_of("quiet") == 0 {
+            if let Ok(val) = config.get_bool("quiet") {
+                self.quiet = val;
+            }
+        }
+        if args.occurrences_of("loglevel") == 0 {
+            if let Ok(val) = config.get_str("loglevel") {
+                self.loglevel = log::LevelFilter::from_str(&val)
+                    .with_context(|| Code::OR1006("loglevel".into()))?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/commands/cmd-shell/src/lib.rs
+++ b/commands/cmd-shell/src/lib.rs
@@ -1,63 +1,35 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_trait::async_trait;
-use clap::{ArgMatches, Clap};
+use clap::Clap;
 use oro_command::OroCommand;
-use oro_command::OroCommandLayerConfig;
-use oro_config::OroConfig;
-use oro_error_code::OroErrCode as Code;
 use std::path::PathBuf;
-use std::str::FromStr;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, Clap, OroCommand)]
 pub struct ShellCmd {
     #[clap(long, default_value = "node")]
     node: String,
 
-    #[clap(long)]
+    #[clap(from_global)]
     data_dir: Option<PathBuf>,
-
-    #[clap(multiple = true)]
-    args: Vec<String>,
 
     #[clap(from_global)]
     loglevel: log::LevelFilter,
+
     #[clap(from_global)]
     json: bool,
+
     #[clap(from_global)]
     quiet: bool,
+
+    #[clap(multiple = true)]
+    #[oro_config(ignore)]
+    args: Vec<String>,
 }
 
 #[async_trait]
 impl OroCommand for ShellCmd {
     async fn execute(self) -> Result<()> {
         dbg!(&self);
-        Ok(())
-    }
-}
-
-impl OroCommandLayerConfig for ShellCmd {
-    fn layer_config(&mut self, args: ArgMatches, config: OroConfig) -> Result<()> {
-        if args.occurrences_of("node") == 0 {
-            if let Ok(val) = config.get_str("node") {
-                self.node = String::from_str(&val)?;
-            }
-        }
-        if args.occurrences_of("json") == 0 {
-            if let Ok(val) = config.get_bool("json") {
-                self.json = val;
-            }
-        }
-        if args.occurrences_of("quiet") == 0 {
-            if let Ok(val) = config.get_bool("quiet") {
-                self.quiet = val;
-            }
-        }
-        if args.occurrences_of("loglevel") == 0 {
-            if let Ok(val) = config.get_str("loglevel") {
-                self.loglevel = log::LevelFilter::from_str(&val)
-                    .with_context(|| Code::OR1006("loglevel".into()))?;
-            }
-        }
         Ok(())
     }
 }

--- a/crates/oro-command-derive/src/lib.rs
+++ b/crates/oro-command-derive/src/lib.rs
@@ -19,9 +19,45 @@ struct OroCommand {
 }
 
 #[derive(Debug, FromField)]
+#[darling(forward_attrs)]
 struct OroCommandField {
     ident: Option<syn::Ident>,
     ty: syn::Type,
+    attrs: Vec<syn::Attribute>,
+}
+
+fn inner_type_of_option(ty: &syn::Type) -> Option<&syn::Type> {
+    if let syn::Type::Path(syn::TypePath { path, .. }) = ty {
+        if let Some(p) = path.segments.iter().next() {
+            // TODO: could be extended to support `Vec` too?
+            if p.ident != "Option" {
+                return None;
+            }
+
+            if let syn::PathArguments::AngleBracketed(ab) = &p.arguments {
+                match ab.args.first() {
+                    Some(syn::GenericArgument::Type(t)) => return Some(t),
+                    _ => {}
+                }
+            }
+        }
+    }
+    None
+}
+
+fn oro_ignored(attr: &syn::Attribute) -> bool {
+    if let Ok(syn::Meta::List(meta_list)) = attr.parse_meta() {
+        if meta_list.path.get_ident().unwrap() == "oro_config" {
+            if let Some(syn::NestedMeta::Meta(syn::Meta::Path(p))) = meta_list.nested.first() {
+                return p.get_ident().unwrap() == "ignore";
+            }
+        }
+    }
+    false
+}
+
+fn should_be_ignored(field: &OroCommandField) -> bool {
+    field.attrs.iter().any(|attr| oro_ignored(attr))
 }
 
 impl ToTokens for OroCommand {
@@ -38,18 +74,33 @@ impl ToTokens for OroCommand {
                 "Enums not supported by derive macro. Implement OroCommandLayerConfig manually.",
             )
             .fields;
-        let field_defs = fields.clone().into_iter().map(|field| {
-            let OroCommandField { ident, ty, .. } = field;
-            let ident = ident.clone().unwrap();
-            let lit_str = Lit::Str(LitStr::new(&ident.to_string(), ident.span()));
-            quote! {
-                if args.occurrences_of(#lit_str) == 0 {
-                    if let Ok(val) = config.get_str(#lit_str) {
-                        self.#ident = #ty::from_str(&val)?;
+        let field_defs = fields
+            .clone()
+            .into_iter()
+            .filter(|field| !should_be_ignored(field))
+            .map(|field| {
+                let OroCommandField { ident, ty, .. } = field;
+                let ident = ident.clone().unwrap();
+                let lit_str = Lit::Str(LitStr::new(&ident.to_string(), ident.span()));
+
+                if let Some(inner) = inner_type_of_option(ty) {
+                    quote! {
+                        if args.occurrences_of(#lit_str) == 0 {
+                            if let Ok(val) = config.get_str(#lit_str) {
+                                self.#ident = #inner::from_str(&val).ok();
+                            }
+                        }
+                    }
+                } else {
+                    quote! {
+                        if args.occurrences_of(#lit_str) == 0 {
+                            if let Ok(val) = config.get_str(#lit_str) {
+                                self.#ident = #ty::from_str(&val)?;
+                            }
+                        }
                     }
                 }
-            }
-        });
+            });
 
         let ts = quote! {
             mod oro_command_layer_config {

--- a/crates/oro-error-code/src/lib.rs
+++ b/crates/oro-error-code/src/lib.rs
@@ -40,4 +40,8 @@ pub enum OroErrCode {
     /// Failed to parse registry URL given to ping
     #[display(fmt = "OR1005: Failed to parse registry URL from `{}`", _0)]
     OR1005(String),
+
+    /// Failed to parse value from config
+    #[display(fmt = "OR1005: Failed read to value from conifg `{}`", _0)]
+    OR1006(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use oro_config::{OroConfig, OroConfigOptions};
 
 use cmd_ping::PingCmd;
 use cmd_restore::RestoreCmd;
+use cmd_shell::ShellCmd;
 use cmd_view::ViewCmd;
 
 pub use oro_error_code::OroErrCode as Code;
@@ -123,12 +124,14 @@ pub enum OroCmd {
         setting = clap::AppSettings::DeriveDisplayOrder,
     )]
     View(ViewCmd),
-    // #[clap(
-    //     about = "Execute a new wrapped `node` shell.",
-    //     alias = "sh",
-    //     setting = clap::AppSettings::TrailingVarArg
-    // )]
-    // Shell(ShellCmd),
+    #[clap(
+        about = "Execute a new wrapped `node` shell.",
+        alias = "sh",
+        setting = clap::AppSettings::ColoredHelp,
+        setting = clap::AppSettings::DisableHelpSubcommand,
+        setting = clap::AppSettings::DeriveDisplayOrder,
+    )]
+    Shell(ShellCmd),
 }
 
 #[async_trait]
@@ -139,6 +142,7 @@ impl OroCommand for Orogene {
             OroCmd::Ping(ping) => ping.execute().await,
             OroCmd::Restore(restore) => restore.execute().await,
             OroCmd::View(view) => view.execute().await,
+            OroCmd::Shell(shell) => shell.execute().await,
         }
     }
 }
@@ -154,6 +158,9 @@ impl OroCommandLayerConfig for Orogene {
             }
             OroCmd::View(ref mut view) => {
                 view.layer_config(args.subcommand_matches("view").unwrap().clone(), conf)
+            }
+            OroCmd::Shell(ref mut shell) => {
+                shell.layer_config(args.subcommand_matches("shell").unwrap().clone(), conf)
             }
         }
     }


### PR DESCRIPTION
Only deals with parsing the arguments that were originally in the `ds` client.