### PR TITLE
fix license links in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,6 +5,6 @@ Members](MEMBERS.md), as defined in the [cross-licensing
 terms](CROSS_LICENSE.md).
 
 All contributions by Members are licensed under [the Parity
-License](LICENSE_PARITY.md). Non-member contributions are licensed under
-[Apache 2.0](LICENSE_APACHE.md).
+License](LICENSE-PARITY.md). Non-member contributions are licensed under
+[Apache 2.0](LICENSE-APACHE.md).
 


### PR DESCRIPTION
the links in README are fine, but the ones in LICENSE were _ instead of -.