### PR TITLE
Implement some arithmetic operations on version ranges

### DIFF
--- a/crates/oro-node-semver/README.md
+++ b/crates/oro-node-semver/README.md
@@ -1,0 +1,33 @@
+# Oro Node Semver
+
+
+TODO:
+
+https://github.com/dart-lang/pub_semver/blob/master/lib/src/version_range.dart cotains a good impl of below operations needed for PubGrub
+
+
+* bool allowsAll(VersionConstraint other);
+  /// Returns `true` if this constraint allows all the versions that [other]
+  /// allows.
+  e.g. foo.allowsAll(other) // foo ^1.5.0 is a subset of foo ^1.0.0
+
+
+* bool allowsAny(VersionConstraint other);
+  /// Returns `true` if this constraint allows any of the versions that [other]
+  /// allows.
+  e.g. !foo.allowsAny(other) // foo ^2.0.0 is disjoint with foo ^1.0.0
+
+* VersionConstraint difference(VersionConstraint other);
+  /// Returns a [VersionConstraint] that allows [Version]s allowed by this but
+  /// not [other].
+  e.g. positive.constraint.difference(negative.constraint) // foo ^1.0.0 ∩ not foo ^1.5.0 → foo >=1.0.0 <1.5.0
+
+* VersionConstraint intersect(VersionConstraint other);
+  /// Returns a [VersionConstraint] that only allows [Version]s allowed by both
+  /// this and [other].
+  e.g. constraint.intersect(other.constraint); // foo ^1.0.0 ∩ foo >=1.5.0 <3.0.0 → foo ^1.5.0
+
+* VersionConstraint union(VersionConstraint other);
+  /// Returns a [VersionConstraint] that allows [Version]s allowed by either
+  /// this or [other].
+  e.g. constraint.union(other.constraint); // not foo ^1.0.0 ∩ not foo >=1.5.0 <3.0.0 → not foo >=1.0.0 <3.0.0

--- a/crates/oro-node-semver/src/version_req.rs
+++ b/crates/oro-node-semver/src/version_req.rs
@@ -41,7 +41,7 @@ impl Range {
     fn exact(version: Version) -> Self {
         Range::new(
             Predicate::Including(version.clone()),
-            Predicate::Including(version.clone()),
+            Predicate::Including(version),
         )
     }
 
@@ -160,9 +160,7 @@ impl Range {
             }
             (Excluding(v1), Excluding(v2)) => Excluding(std::cmp::min(v1, v2).clone()),
             (Excluding(v1), Including(v2)) => {
-                if v1 < v2 {
-                    Excluding(v1.clone())
-                } else if v1 == v2 {
+                if v1 <= v2 {
                     Excluding(v1.clone())
                 } else {
                     Including(v2.clone())

--- a/crates/oro-node-semver/src/version_req.rs
+++ b/crates/oro-node-semver/src/version_req.rs
@@ -191,7 +191,7 @@ impl fmt::Display for Range {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Predicate::*;
         match (&self.lower, &self.upper) {
-            (Unbounded, Unbounded) => write!(f, "WAT"), // TODO
+            (Unbounded, Unbounded) => write!(f, "*"),
             (Unbounded, Including(v)) => write!(f, "<={}", v),
             (Unbounded, Excluding(v)) => write!(f, "<{}", v),
             (Including(v), Unbounded) => write!(f, ">={}", v),

--- a/crates/oro-node-semver/src/version_req.rs
+++ b/crates/oro-node-semver/src/version_req.rs
@@ -658,16 +658,12 @@ mod math {
                 fn $name() {
                     let version_range = VersionReq::parse($version_range).unwrap();
 
-                    let allows: Vec<&str> = $allows.into();
-                    let ranges = allows.iter().map(|v| VersionReq::parse(v).unwrap()).collect::<Vec<_>>();
-
-                    for version in &ranges {
+                    let allows: Vec<VersionReq> = $allows.iter().map(|v| VersionReq::parse(v).unwrap()).collect();
+                    for version in &allows {
                         assert!(version_range.allows_all(version), "should have allowed: {}", version);
                     }
 
-                    let denials: Vec<&str> = $denies.into();
-                    let ranges: Vec<VersionReq> = denials.iter().map(|v| VersionReq::parse(v).unwrap()).collect::<Vec<_>>();
-
+                    let ranges: Vec<VersionReq> = $denies.iter().map(|v| VersionReq::parse(v).unwrap()).collect();
                     for version in &ranges {
                         assert!(!version_range.allows_all(version), "should have denied: {}", version);
                     }

--- a/crates/oro-node-semver/src/version_req.rs
+++ b/crates/oro-node-semver/src/version_req.rs
@@ -237,16 +237,6 @@ impl fmt::Display for Operation {
 }
 
 impl VersionReq {
-    pub fn satisfies(&self, version: &Version) -> bool {
-        for range in &self.predicates {
-            if range.satisfies(version) {
-                return true;
-            }
-        }
-
-        false
-    }
-
     pub fn parse<S: AsRef<str>>(input: S) -> Result<Self, SemverError> {
         let input = &input.as_ref()[..];
 
@@ -261,6 +251,25 @@ impl VersionReq {
                 },
             }),
         }
+    }
+
+    pub fn any() -> Self {
+        Self {
+            predicates: vec![Range {
+                upper: Predicate::Unbounded,
+                lower: Predicate::Unbounded,
+            }],
+        }
+    }
+
+    pub fn satisfies(&self, version: &Version) -> bool {
+        for range in &self.predicates {
+            if range.satisfies(version) {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn allows_all(&self, other: &VersionReq) -> bool {
@@ -287,6 +296,7 @@ impl VersionReq {
         false
     }
 
+    // TODO: This needs to loop better
     pub fn intersect(&self, other: &Self) -> Option<Self> {
         let lefty = &self.predicates[0];
         let righty = &other.predicates[0];


### PR DESCRIPTION
Version ranges can be compared with

`a.allows_any(b)` to see if there is any version that both `a` and `b` support.
`a.allows_all(b)` to see if all version in `b` are also supported in `a`
`a.satisfies(v)` to see if version `v` is supported in range `a`.