### PR TITLE
Generate tarball from files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,12 +169,39 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f47c78ea98277cb1f5e6f60ba4fc762f5eafe9f6511bc2f7dfd8b75c225650"
 dependencies = [
- "async-io",
- "futures-lite",
+ "async-io 0.1.11",
+ "futures-lite 0.1.11",
  "multitask",
  "parking 1.0.6",
  "scoped-tls",
  "waker-fn",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
+dependencies = [
+ "async-task 4.0.2",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite 1.11.1",
+ "once_cell",
+ "vec-arena 1.0.0",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
+dependencies = [
+ "async-executor 1.3.0",
+ "async-io 1.1.0",
+ "futures-lite 1.11.1",
+ "num_cpus",
+ "once_cell",
 ]
 
 [[package]]
@@ -201,13 +228,35 @@ checksum = "3ae22a338d28c75b53702b66f77979062cb29675db376d99e451af4fa79dedb3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "futures-lite",
+ "futures-lite 0.1.11",
  "libc",
  "once_cell",
  "parking 2.0.0",
- "polling",
+ "polling 0.1.5",
  "socket2",
- "vec-arena",
+ "vec-arena 0.5.2",
+ "wepoll-sys-stjepang",
+ "winapi",
+]
+
+[[package]]
+name = "async-io"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38628c78a34f111c5a6b98fc87dfc056cd1590b61afe748b145be4623c56d194"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite 1.11.1",
+ "libc",
+ "log",
+ "once_cell",
+ "parking 2.0.0",
+ "polling 1.0.2",
+ "socket2",
+ "vec-arena 1.0.0",
+ "waker-fn",
  "wepoll-sys-stjepang",
  "winapi",
 ]
@@ -235,22 +284,21 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.3"
+version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c8da367da62b8ff2313c406c9ac091c1b31d67a165becdd2de380d846260f7"
+checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
 dependencies = [
  "async-attributes",
- "async-executor",
- "async-io",
+ "async-global-executor",
+ "async-io 1.1.0",
  "async-mutex",
- "async-task",
- "blocking 0.5.2",
+ "blocking 1.0.2",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite",
- "futures-timer",
+ "futures-lite 1.11.1",
+ "gloo-timers",
  "kv-log-macro",
  "log",
  "memchr",
@@ -277,10 +325,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb619eae01ab289095debb1ff7c02710d5124c20edde1b2eca926572a34c3998"
+dependencies = [
+ "async-std",
+ "filetime",
+ "libc",
+ "pin-project",
+ "redox_syscall",
+ "xattr",
+]
+
+[[package]]
 name = "async-task"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
+
+[[package]]
+name = "async-task"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
 name = "async-trait"
@@ -442,7 +510,7 @@ checksum = "d2468ff7bf85066b4a3678fede6fe66db31846d753ff0adfbfab2c6a6e81612b"
 dependencies = [
  "async-channel",
  "atomic-waker",
- "futures-lite",
+ "futures-lite 0.1.11",
  "once_cell",
  "parking 1.0.6",
  "waker-fn",
@@ -456,9 +524,23 @@ checksum = "ea5800d29218fea137b0880387e5948694a23c93fcdde157006966693a865c7c"
 dependencies = [
  "async-channel",
  "atomic-waker",
- "futures-lite",
+ "futures-lite 0.1.11",
  "once_cell",
  "waker-fn",
+]
+
+[[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task 4.0.2",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite 1.11.1",
+ "once_cell",
 ]
 
 [[package]]
@@ -1334,6 +1416,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-lite"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381a7ad57b1bad34693f63f6f377e1abded7a9c85c9d3eb6771e11c60aaadab9"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking 2.0.0",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,16 +1455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-dependencies = [
- "gloo-timers",
- "send_wrapper",
 ]
 
 [[package]]
@@ -1832,7 +1919,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c09c35271e7dcdb5f709779111f2c8e8ab8e06c1b587c1c6a9e179d865aaa5b4"
 dependencies = [
- "async-task",
+ "async-task 3.0.0",
  "concurrent-queue",
  "fastrand",
 ]
@@ -2123,6 +2210,8 @@ dependencies = [
 name = "oro-pack"
 version = "0.1.0"
 dependencies = [
+ "async-std",
+ "async-tar 0.3.0",
  "gitignored",
  "oro-manifest",
  "serde_json",
@@ -2294,6 +2383,19 @@ checksum = "9e09dffb745feffca5be3dea51c02b7b368c4597ab0219a82acaf9799ab3e0d1"
 dependencies = [
  "cfg-if",
  "libc",
+ "wepoll-sys-stjepang",
+ "winapi",
+]
+
+[[package]]
+name = "polling"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5388c2f19adcd6c462b8ca7db12b2c67e4c11c3d084361d1f5203d4389d990"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
  "wepoll-sys-stjepang",
  "winapi",
 ]
@@ -2515,7 +2617,7 @@ version = "0.1.0"
 dependencies = [
  "async-compression",
  "async-std",
- "async-tar",
+ "async-tar 0.2.0",
  "async-trait",
  "bincode",
  "cacache",
@@ -2662,12 +2764,6 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -2835,7 +2931,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "620cbb3c6e34da57d3a248cda0cd01cd5848164dc062e764e65d06fe3ea7aed5"
 dependencies = [
- "async-task",
+ "async-task 3.0.0",
  "blocking 0.4.7",
  "concurrent-queue",
  "fastrand",
@@ -2857,12 +2953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67583f4ccc13bbb105a0752058d8ad66c47753d85445952809bcaca891954f83"
 dependencies = [
  "async-channel",
- "async-executor",
- "async-io",
+ "async-executor 0.1.2",
+ "async-io 0.1.11",
  "blocking 0.5.2",
  "cfg-if",
  "easy-parallel",
- "futures-lite",
+ "futures-lite 0.1.11",
  "num_cpus",
 ]
 
@@ -3500,6 +3596,12 @@ name = "vec-arena"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb18268690309760d59ee1a9b21132c126ba384f374c59a94db4bc03adeb561"
+
+[[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "vec_map"

--- a/crates/oro-pack/Cargo.toml
+++ b/crates/oro-pack/Cargo.toml
@@ -11,6 +11,8 @@ oro-manifest = { path = "../oro-manifest" }
 gitignored = "0.4.0"
 serde_json = "1.0"
 walkdir = "2"
+async-tar = "0.3.0"
+async-std = "1.6.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/oro-pack/src/lib.rs
+++ b/crates/oro-pack/src/lib.rs
@@ -1,5 +1,5 @@
 use async_std::fs::File;
-use async_std::io as AsyncIO;
+use async_std::io as aio;
 use async_std::task::block_on;
 use async_tar::Builder;
 use gitignored::Gitignore;
@@ -115,7 +115,7 @@ impl OroPack {
             .collect()
     }
 
-    async fn archive_files(&self) -> AsyncIO::Result<()> {
+    async fn archive_files(&self) -> aio::Result<()> {
         let manifest = self.pkg.as_ref().unwrap();
         let pkg_name = manifest.name.as_ref().unwrap();
 
@@ -130,7 +130,7 @@ impl OroPack {
         Ok(())
     }
 
-    pub fn pack(&self) -> AsyncIO::Result<()> {
+    pub fn pack(&self) -> aio::Result<()> {
         block_on(self.archive_files())?;
 
         Ok(())

--- a/crates/oro-pack/src/lib.rs
+++ b/crates/oro-pack/src/lib.rs
@@ -119,12 +119,12 @@ impl OroPack {
         let manifest = self.pkg.as_ref().unwrap();
         let pkg_name = manifest.name.as_ref().unwrap();
 
-        let file = File::create(format!("{}.tar", pkg_name)).await.unwrap();
+        let file = File::create(format!("{}.tar", pkg_name)).await?;
         let mut archive = Builder::new(file);
         let paths = self.project_paths();
 
         for path in &paths {
-            archive.append_path(path).await.unwrap();
+            archive.append_path(path).await?;
         }
 
         Ok(())

--- a/crates/oro-pack/tests/outputs-archive.rs
+++ b/crates/oro-pack/tests/outputs-archive.rs
@@ -1,0 +1,90 @@
+use async_std::fs::File as AsyncFile;
+use async_std::io as AsyncIO;
+use async_std::prelude::*;
+use async_std::task::block_on;
+use async_tar::Archive;
+use fs::File;
+use oro_pack::OroPack;
+use std::env;
+use std::fs;
+use std::io::Write as _;
+use tempfile::tempdir;
+
+async fn load_archive() -> AsyncIO::Result<Vec<String>> {
+    let mut archived_files: Vec<String> = Vec::new();
+
+    let archive = Archive::new(AsyncFile::open("testpackage.tar").await.unwrap());
+    let mut entries = archive.entries().unwrap();
+
+    while let Some(f) = entries.next().await {
+        let file = f.unwrap();
+        let path = file.path();
+        archived_files.push(path.unwrap().display().to_string());
+    }
+
+    Ok(archived_files)
+}
+
+#[test]
+fn outputs_archive() -> AsyncIO::Result<()> {
+    let cwd = env::current_dir()?;
+
+    let dir = tempdir()?;
+    let dir_path = dir.path();
+    let pkg_path = dir_path.join("package.json");
+
+    let mut pkg_json = File::create(pkg_path)?;
+
+    pkg_json.write_all(
+        r#"
+    { 
+        "name": "testpackage",
+        "files": [
+          "lib/index.js",
+          "lib/index.es.js",
+          "!lib/*.png"
+        ]
+    }
+    "#
+        .as_bytes(),
+    )?;
+
+    fs::create_dir_all(dir_path.join("lib")).unwrap();
+
+    let _a = File::create(dir_path.join("README.md"))?;
+    let _b = File::create(dir_path.join("lib/index.js"))?;
+    let _c = File::create(dir_path.join("lib/index.es.js"))?;
+    let _d = File::create(dir_path.join("lib/pic.png"))?;
+
+    env::set_current_dir(dir.path())?;
+
+    let mut pack = OroPack::new();
+
+    pack.load();
+
+    pack.pack()?;
+
+    let expected_paths = vec![
+        "README.md",
+        "lib/index.es.js",
+        "lib/index.js",
+        "package.json",
+    ];
+
+    let archived_files = block_on(load_archive())?;
+
+    assert_eq!(expected_paths, archived_files);
+
+    env::set_current_dir(cwd)?;
+
+    drop(pkg_json);
+
+    drop(_a);
+    drop(_b);
+    drop(_c);
+    drop(_d);
+
+    dir.close()?;
+
+    Ok(())
+}

--- a/crates/oro-pack/tests/outputs-archive.rs
+++ b/crates/oro-pack/tests/outputs-archive.rs
@@ -1,5 +1,5 @@
 use async_std::fs::File as AsyncFile;
-use async_std::io as AsyncIO;
+use async_std::io as aio;
 use async_std::prelude::*;
 use async_std::task::block_on;
 use async_tar::Archive;
@@ -10,7 +10,7 @@ use std::fs;
 use std::io::Write as _;
 use tempfile::tempdir;
 
-async fn load_archive() -> AsyncIO::Result<Vec<String>> {
+async fn load_archive() -> aio::Result<Vec<String>> {
     let mut archived_files: Vec<String> = Vec::new();
 
     let archive = Archive::new(AsyncFile::open("testpackage.tar").await.unwrap());
@@ -26,7 +26,7 @@ async fn load_archive() -> AsyncIO::Result<Vec<String>> {
 }
 
 #[test]
-fn outputs_archive() -> AsyncIO::Result<()> {
+fn outputs_archive() -> aio::Result<()> {
     let cwd = env::current_dir()?;
 
     let dir = tempdir()?;


### PR DESCRIPTION
This PR addresses #80

It adds a `pack` function that can create a tarball from valid paths (those in `files` field).
It adds a test that packs and reads the archive from a temporary directory and compares the result with expected paths.