### PR TITLE
use graph edges to compute node's dependencies

### DIFF
--- a/crates/node-maintainer/src/graph.rs
+++ b/crates/node-maintainer/src/graph.rs
@@ -9,6 +9,8 @@ use nassun::{Package, PackageResolution};
 use petgraph::{
     dot::Dot,
     stable_graph::{EdgeIndex, NodeIndex, StableGraph},
+    visit::EdgeRef,
+    Direction,
 };
 use unicase::UniCase;
 
@@ -205,25 +207,19 @@ impl Graph {
         let mut dev_deps = HashMap::new();
         let mut peer_deps = HashMap::new();
         let mut opt_deps = HashMap::new();
-        if !node.dependencies.is_empty() {
-            let dependencies = node
-                .dependencies
-                .iter()
-                .map(|(name, edge_idx)| {
-                    let edge = &self.inner[*edge_idx];
-                    (name, &edge.requested, &edge.dep_type)
-                })
-                .collect::<Vec<_>>();
-            for (name, requested, dep_type) in dependencies {
-                use DepType::*;
-                let deps = match dep_type {
-                    Prod => &mut prod_deps,
-                    Dev => &mut dev_deps,
-                    Peer => &mut peer_deps,
-                    Opt => &mut opt_deps,
-                };
-                deps.insert(name.to_string(), requested.requested().clone());
-            }
+        for e in self.inner.edges_directed(node.idx, Direction::Outgoing) {
+            use DepType::*;
+
+            let name = self.inner[e.target()].package.name();
+            let edge = e.weight();
+
+            let deps = match edge.dep_type {
+                Prod => &mut prod_deps,
+                Dev => &mut dev_deps,
+                Peer => &mut peer_deps,
+                Opt => &mut opt_deps,
+            };
+            deps.insert(name.to_string(), edge.requested.requested().clone());
         }
         Ok(LockfileNode {
             name: UniCase::new(node.package.name().to_string()),

--- a/crates/node-maintainer/src/maintainer.rs
+++ b/crates/node-maintainer/src/maintainer.rs
@@ -386,14 +386,11 @@ impl NodeMaintainer {
                 .resolved()
                 .satisfies(&requested)?
             {
-                let edge_idx = graph.inner.add_edge(
+                graph.inner.add_edge(
                     dep.node_idx,
                     satisfier_idx,
                     Edge::new(requested.clone(), dep.dep_type.clone()),
                 );
-                graph[dep.node_idx]
-                    .dependencies
-                    .insert(dep.name.clone(), edge_idx);
                 return Ok(true);
             }
             return Ok(false);
@@ -463,7 +460,7 @@ impl NodeMaintainer {
 
         // Edges represent the logical dependency relationship (not the
         // hierarchy location).
-        let edge_idx = graph.inner.add_edge(
+        graph.inner.add_edge(
             dependent_idx,
             child_idx,
             Edge::new(requested.clone(), dep_type),
@@ -520,12 +517,6 @@ impl NodeMaintainer {
             // The parent is the _hierarchy_ location, so we set its parent
             // accordingly.
             child_node.parent = Some(target_idx);
-        }
-        {
-            // Now we set backlinks: first, the dependent node needs to point
-            // to the child, wherever it is in the graph.
-            let dependent = &mut graph[dependent_idx];
-            dependent.dependencies.insert(child_name.clone(), edge_idx);
         }
         {
             // Finally, we add the backlink from the parent node to the child.

--- a/crates/node-maintainer/src/node.rs
+++ b/crates/node-maintainer/src/node.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use nassun::Package;
 use oro_common::CorgiManifest;
-use petgraph::stable_graph::{EdgeIndex, NodeIndex};
+use petgraph::stable_graph::NodeIndex;
 use unicase::UniCase;
 
 use crate::Graph;
@@ -17,8 +17,6 @@ pub struct Node {
     pub(crate) manifest: CorgiManifest,
     /// Quick index back to this Node's [`Graph`]'s root Node.
     pub(crate) root: NodeIndex,
-    /// Name-indexed map of outgoing [`crate::Edge`]s from this Node.
-    pub(crate) dependencies: HashMap<UniCase<String>, EdgeIndex>,
     /// Parent, if any, of this Node in the logical filesystem hierarchy.
     pub(crate) parent: Option<NodeIndex>,
     /// Children of this node in the logical filesystem hierarchy. These are
@@ -36,7 +34,6 @@ impl Node {
             root: NodeIndex::new(0),
             parent: None,
             children: HashMap::new(),
-            dependencies: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
This is just a stepping stone for the optimization changes that I'm making. As a part of upcoming PR I'll need to clone and move nodes around in the tree/graph, and it is really not easy if I also need to keep the auxiliary dependencies hashmap. Given that this information is already present as edges in the directional graph, maybe it is okay to just use that?