### PR TITLE
optimize package-lock post resolve

### DIFF
--- a/crates/nassun/src/resolver.rs
+++ b/crates/nassun/src/resolver.rs
@@ -76,6 +76,13 @@ impl PackageResolution {
             _ => false,
         })
     }
+
+    pub fn npm_version(&self) -> Option<SemVerVersion> {
+        match self {
+            Self::Npm { version, .. } => Some(version.clone()),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/node-maintainer/src/maintainer.rs
+++ b/crates/node-maintainer/src/maintainer.rs
@@ -7,6 +7,7 @@ use async_std::fs;
 use async_std::sync::{Arc, Mutex};
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
 use nassun::{Nassun, NassunOpts, Package, PackageSpec};
+use node_semver::Version as SemVerVersion;
 use oro_common::CorgiManifest;
 use petgraph::stable_graph::NodeIndex;
 use petgraph::visit::EdgeRef;
@@ -82,6 +83,7 @@ impl NodeMaintainerOptions {
         let node = nm.graph.inner.add_node(Node::new(root_pkg, root));
         nm.graph[node].root = node;
         nm.run_resolver(self.kdl_lock).await?;
+        nm.optimize(nm.graph.root);
         Ok(nm)
     }
 
@@ -100,6 +102,7 @@ impl NodeMaintainerOptions {
         let node = nm.graph.inner.add_node(Node::new(root_pkg, corgi));
         nm.graph[node].root = node;
         nm.run_resolver(self.kdl_lock).await?;
+        nm.optimize(nm.graph.root);
         Ok(nm)
     }
 }
@@ -553,6 +556,110 @@ impl NodeMaintainer {
             Box::new(deps.chain(manifest.dev_dependencies.iter().map(|x| (x, DepType::Dev))))
         } else {
             Box::new(deps)
+        }
+    }
+
+    fn optimize(&mut self, node_idx: NodeIndex) {
+        let mut q = Vec::new();
+        q.push(node_idx);
+
+        let mut i = 0;
+        while i < q.len() {
+            q.extend(self.graph.inner[q[i]].children.values());
+            i += 1;
+        }
+
+        // Optimize children first and parents later so that we could keep
+        // promoting node to the root if needed.
+        for idx in q.into_iter().rev() {
+            self.optimize_subtree(idx);
+        }
+    }
+
+    fn optimize_subtree(&mut self, node_idx: NodeIndex) {
+        // Find children that can be demoted (move deeper into the tree).
+        let node = &self.graph.inner[node_idx];
+        let demotable = node.get_demotable_children(&self.graph);
+
+        // Build a hashmap from a grand children's package name to a vector of
+        // node indices.
+        // Any of these grand children can be promoted (moved higher in the
+        // tree).
+        let mut promotable: HashMap<String, Vec<NodeIndex>> = HashMap::new();
+        for &child_idx in node.children.values() {
+            let child = &self.graph.inner[child_idx];
+            for &idx in child.children.values() {
+                let name = self.graph.inner[idx].package.name();
+
+                if let Some(list) = promotable.get_mut(name) {
+                    list.push(idx);
+                } else {
+                    promotable.insert(name.to_string(), vec![idx]);
+                }
+            }
+        }
+
+        // For each demotable child
+        for child_idx in demotable {
+            // That is an npm package
+            let child = &self.graph.inner[child_idx];
+            let child_version = child.package.resolved().npm_version();
+            if child_version.is_none() {
+                continue;
+            }
+
+            // Take every promotable child with the same name and build a map
+            // from version to the vector of indexes.
+            let mut promotable_by_version: HashMap<SemVerVersion, Vec<NodeIndex>> = HashMap::new();
+            if let Some(promotable) = promotable.remove(child.package.name()) {
+                for promotable_idx in promotable {
+                    // Promotable grand child might have different index if we
+                    // previously demoted its parent. Skip.
+                    if !self.graph.inner.contains_node(promotable_idx) {
+                        continue;
+                    }
+
+                    let promotable = &self.graph.inner[promotable_idx];
+                    if let Some(version) = promotable.package.resolved().npm_version() {
+                        if let Some(group) = promotable_by_version.get_mut(&version) {
+                            group.push(promotable_idx);
+                        } else {
+                            promotable_by_version.insert(version, vec![promotable_idx]);
+                        }
+                    }
+                }
+            }
+
+            // Find the most populated promotable version
+            let largest_group = promotable_by_version.into_values().reduce(|acc, group| {
+                if acc.len() < group.len() {
+                    group
+                } else {
+                    acc
+                }
+            });
+
+            if let Some(largest_group) = largest_group {
+                // Promote only if the promotable version has more duplicated
+                // packages than we'd have to create if we demote the current
+                // node.
+                let targets = self.graph.get_demotion_targets(child_idx);
+                if largest_group.len() <= targets.len() {
+                    continue;
+                }
+
+                // This is a costly check so perform it only when we are about
+                // to run the optimization.
+                if !self.graph.can_be_promoted(largest_group[0]) {
+                    continue;
+                }
+
+                // Promote group
+                self.graph.merge_and_promote(node_idx, &largest_group);
+
+                // Demote node
+                self.graph.clone_and_demote(child_idx, &targets);
+            }
         }
     }
 }

--- a/crates/node-maintainer/src/node.rs
+++ b/crates/node-maintainer/src/node.rs
@@ -7,7 +7,7 @@ use unicase::UniCase;
 
 use crate::Graph;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node {
     /// Index of this Node inside its [`Graph`].
     pub(crate) idx: NodeIndex,
@@ -46,5 +46,13 @@ impl Node {
             current = graph.inner[idx].parent;
         }
         depth
+    }
+
+    /// A vector of Node's children that are not its direct dependencies.
+    pub(crate) fn get_demotable_children(&self, graph: &Graph) -> Vec<NodeIndex> {
+        self.children
+            .values()
+            .filter_map(|&idx| (!graph.is_dependency(self.idx, idx)).then_some(idx))
+            .collect()
     }
 }


### PR DESCRIPTION
I feel like I should write tests for this, but let me know if you'd like me to contribute them separately!

Before:
```
% cat package-lock.kdl | grep -o "resolved.*" | wc -l
    1415
```

After:
```
% cat package-lock.kdl | grep -o "resolved.*" | wc -l
    1243
```