### PR TITLE
validate graph after optimization

### DIFF
--- a/crates/node-maintainer/src/error.rs
+++ b/crates/node-maintainer/src/error.rs
@@ -83,6 +83,10 @@ pub enum NodeMaintainerError {
     #[error("Failed to send data through mpsc channel.")]
     #[diagnostic(code(node_maintainer::mpsc_error))]
     TrySendError,
+
+    #[error("{0}")]
+    #[diagnostic(code(node_maintainer::graph_error))]
+    GraphValidationError(String),
 }
 
 impl<T> From<mpsc::TrySendError<T>> for NodeMaintainerError {

--- a/crates/node-maintainer/src/maintainer.rs
+++ b/crates/node-maintainer/src/maintainer.rs
@@ -83,7 +83,7 @@ impl NodeMaintainerOptions {
         let node = nm.graph.inner.add_node(Node::new(root_pkg, root));
         nm.graph[node].root = node;
         nm.run_resolver(self.kdl_lock).await?;
-        nm.optimize(nm.graph.root);
+        nm.optimize(nm.graph.root)?;
         Ok(nm)
     }
 
@@ -102,7 +102,7 @@ impl NodeMaintainerOptions {
         let node = nm.graph.inner.add_node(Node::new(root_pkg, corgi));
         nm.graph[node].root = node;
         nm.run_resolver(self.kdl_lock).await?;
-        nm.optimize(nm.graph.root);
+        nm.optimize(nm.graph.root)?;
         Ok(nm)
     }
 }
@@ -559,7 +559,7 @@ impl NodeMaintainer {
         }
     }
 
-    fn optimize(&mut self, node_idx: NodeIndex) {
+    fn optimize(&mut self, node_idx: NodeIndex) -> Result<(), NodeMaintainerError> {
         let mut q = Vec::new();
         q.push(node_idx);
 
@@ -574,6 +574,11 @@ impl NodeMaintainer {
         for idx in q.into_iter().rev() {
             self.optimize_subtree(idx);
         }
+
+        #[cfg(debug_assertions)]
+        self.graph.validate()?;
+
+        Ok(())
     }
 
     fn optimize_subtree(&mut self, node_idx: NodeIndex) {


### PR DESCRIPTION
In absence of tests (for now), I thought that we could at least validate various graph properties after optimizing it!

Example error produced after disabling `can_be_promoted` check in optimizer:
```
Error: node_maintainer::graph_error

  × Dependency estraverse@4.3.0 (https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz) is unreachable from eslint-scope@5.1.1 (https://
  │ registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz)
```