### PR TITLE
fix(common): handle deprecation booleans in registry response (#244)

### DIFF
--- a/crates/node-maintainer/src/resolver.rs
+++ b/crates/node-maintainer/src/resolver.rs
@@ -206,7 +206,7 @@ impl<'a> Resolver<'a> {
                         if let Some(deprecated) = deprecated {
                             tracing::warn!(
                                 "{} {}@{}: {}",
-                                "deprecated".magenta(),
+                                "deprecated".on_magenta(),
                                 manifest.name.as_ref().unwrap(),
                                 manifest
                                     .version

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use colored::*;
 use humansize::{file_size_opts, FileSize};
 use miette::{IntoDiagnostic, Result, WrapErr};
-use oro_common::{Bin, Manifest, NpmUser, Person, PersonField, VersionMetadata};
+use oro_common::{Bin, DeprecationInfo, Manifest, NpmUser, Person, PersonField, VersionMetadata};
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 
 use crate::commands::OroCommand;
@@ -97,8 +97,13 @@ impl OroCommand for ViewCmd {
             println!();
 
             // DEPRECATED - <deprecation message>
-            if let Some(msg) = deprecated.as_ref() {
-                println!("{} - {}\n", "DEPRECATED".bright_red(), msg);
+            if let Some(info) = deprecated.as_ref() {
+                let deprecated = "DEPRECATED".on_magenta();
+                if let DeprecationInfo::Reason(msg) = info {
+                    println!("{deprecated} {msg}\n");
+                } else {
+                    println!("{deprecated}\n");
+                }
             }
 
             // keywords: foo, bar, baz


### PR DESCRIPTION
+switches the deprecation color to background-magenta for consistency.

could pull common colorized tokens into a module, but it's not too relevant here /shrug

---

thanks to @zkat for the assistance on matrix, and everyone on various activitypub instances' #rust tag that jumped into the path of a nerdsnipe question on api design