### PR TITLE
feat: support proxy

### DIFF
--- a/crates/nassun/src/client.rs
+++ b/crates/nassun/src/client.rs
@@ -106,9 +106,7 @@ impl NassunOpts {
         };
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(url) = self.proxy_url {
-            if self.proxy {
-                client_builder = client_builder.set_proxy_url(url).unwrap();
-            }
+            client_builder = client_builder.set_proxy_url(url).unwrap();
         }
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(url) = self.no_proxy_domain {

--- a/crates/nassun/src/client.rs
+++ b/crates/nassun/src/client.rs
@@ -103,7 +103,7 @@ impl NassunOpts {
             if let Some(proxy_url) = self.proxy_config.proxy_url {
                 client_builder = client_builder.set_proxy_url(proxy_url);
             }
-            if let Some(no_proxy_conf) = self.proxy_config.no_proxy {
+            if let Some(no_proxy_conf) = self.proxy_config.no_proxy_domain {
                 client_builder = client_builder.set_no_proxy(no_proxy_conf);
             }
         }

--- a/crates/nassun/src/client.rs
+++ b/crates/nassun/src/client.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use async_std::sync::Arc;
-use oro_client::{OroClient, OroClientProxyConfig};
+use oro_client::OroClient;
+#[cfg(not(target_arch = "wasm32"))]
+use oro_client::OroClientProxyConfig;
 use oro_common::{CorgiManifest, CorgiPackument, CorgiVersionMetadata, Packument, VersionMetadata};
 use url::Url;
 
@@ -100,9 +102,11 @@ impl NassunOpts {
         };
         #[cfg(not(target_arch = "wasm32"))]
         if self.proxy_config.proxy {
+            #[cfg(not(target_arch = "wasm32"))]
             if let Some(proxy_url) = self.proxy_config.proxy_url {
                 client_builder = client_builder.set_proxy_url(proxy_url);
             }
+            #[cfg(not(target_arch = "wasm32"))]
             if let Some(no_proxy_conf) = self.proxy_config.no_proxy_domain {
                 client_builder = client_builder.set_no_proxy(no_proxy_conf);
             }

--- a/crates/oro-client/src/client.rs
+++ b/crates/oro-client/src/client.rs
@@ -14,17 +14,48 @@ use url::Url;
 
 use crate::OroClientError;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OroClientProxyConfig {
+    pub proxy: bool,
+    pub proxy_url: Option<String>,
+    pub no_proxy: Option<String>,
+}
+
+impl Default for OroClientProxyConfig {
+    fn default() -> Self {
+        Self {
+            proxy: false,
+            proxy_url: None,
+            no_proxy: Some("NO_PROXY".to_string()),
+        }
+    }
+}
+
+impl OroClientProxyConfig {
+    pub fn set_proxy(mut self, proxy: bool) -> Self {
+        self.proxy = proxy;
+        self
+    }
+
+    pub fn set_proxy_url(mut self, proxy_url: impl AsRef<str>) -> Self {
+        self.proxy_url = Some(proxy_url.as_ref().into());
+        self.proxy = true;
+        self
+    }
+
+    pub fn set_no_proxy_url(mut self, no_proxy: impl AsRef<str>) -> Self {
+        self.no_proxy = Some(no_proxy.as_ref().into());
+        self
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct OroClientBuilder {
     registry: Url,
     #[cfg(not(target_arch = "wasm32"))]
     cache: Option<PathBuf>,
     #[cfg(not(target_arch = "wasm32"))]
-    proxy: bool,
-    #[cfg(not(target_arch = "wasm32"))]
-    proxy_url: Option<&'static str>,
-    #[cfg(not(target_arch = "wasm32"))]
-    no_proxy: Option<&'static str>,
+    proxy_config: OroClientProxyConfig,
 }
 
 impl Default for OroClientBuilder {
@@ -34,11 +65,7 @@ impl Default for OroClientBuilder {
             #[cfg(not(target_arch = "wasm32"))]
             cache: None,
             #[cfg(not(target_arch = "wasm32"))]
-            proxy: false,
-            #[cfg(not(target_arch = "wasm32"))]
-            proxy_url: None,
-            #[cfg(not(target_arch = "wasm32"))]
-            no_proxy: Some("NO_PROXY"),
+            proxy_config: OroClientProxyConfig::default(),
         }
     }
 }
@@ -60,19 +87,18 @@ impl OroClientBuilder {
     }
 
     pub fn set_proxy(mut self, proxy: bool) -> Self {
-        self.proxy = proxy;
+        self.proxy_config.proxy = proxy;
         self
     }
 
-    pub fn set_proxy_url<'a>(mut self, proxy_url: &'static str) -> Self {
-        let other = self.clone();
-        self.proxy_url = Some(proxy_url);
-        other.set_proxy(true);
+    pub fn set_proxy_url(mut self, proxy_url: impl AsRef<str>) -> Self {
+        self.proxy_config.proxy_url = Some(proxy_url.as_ref().into());
+        self.proxy_config.proxy = true;
         self
     }
 
-    pub fn set_no_proxy<'a>(mut self, no_proxy: &'static str) -> Self {
-        self.no_proxy = Some(no_proxy);
+    pub fn set_no_proxy(mut self, no_proxy: impl AsRef<str>) -> Self {
+        self.proxy_config.no_proxy = Some(no_proxy.as_ref().into());
         self
     }
 
@@ -87,12 +113,12 @@ impl OroClientBuilder {
             .timeout(std::time::Duration::from_secs(60 * 5));
 
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(url) = self.proxy_url {
+        if let Some(ref url) = self.proxy_config.proxy_url {
             client_core = client_core.proxy(self.set_request_proxy(url).unwrap());
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        if !self.proxy {
+        if !self.proxy_config.proxy {
             client_core = client_core.no_proxy();
         }
 
@@ -126,7 +152,7 @@ impl OroClientBuilder {
 
 
     fn get_no_proxy(&self) -> Option<NoProxy> {
-        if let Some(no_proxy_conf) = self.no_proxy {
+        if let Some(ref no_proxy_conf) = self.proxy_config.no_proxy {
             if no_proxy_conf != "NO_PROXY" || no_proxy_conf != "" {
                 Some(NoProxy::from_string(no_proxy_conf));
             }

--- a/crates/oro-client/src/client.rs
+++ b/crates/oro-client/src/client.rs
@@ -69,7 +69,7 @@ impl OroClientBuilder {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn set_proxy_url(mut self, proxy_url: impl AsRef<str>) -> Result<Self, OroClientError> {
-        match Url::parse(proxy_url.as_ref().into()) {
+        match Url::parse(proxy_url.as_ref()) {
             Ok(url_info) => {
                 let username = url_info.username();
                 let password = url_info.password();
@@ -96,7 +96,7 @@ impl OroClientBuilder {
 
     pub fn build(self) -> OroClient {
         #[cfg(target_arch = "wasm32")]
-        let mut client_uncached = Client::new();
+        let client_uncached = Client::new();
 
         #[cfg(not(target_arch = "wasm32"))]
         let mut client_core = ClientBuilder::new()
@@ -145,7 +145,7 @@ impl OroClientBuilder {
     #[cfg(not(target_arch = "wasm32"))]
     fn get_no_proxy(&self) -> Option<NoProxy> {
         if let Some(ref no_proxy_conf) = self.no_proxy_domain {
-            if no_proxy_conf != "" {
+            if !no_proxy_conf.is_empty() {
                 return NoProxy::from_string(no_proxy_conf);
             }
         }

--- a/crates/oro-client/src/client.rs
+++ b/crates/oro-client/src/client.rs
@@ -18,7 +18,7 @@ use crate::OroClientError;
 pub struct OroClientProxyConfig {
     pub proxy: bool,
     pub proxy_url: Option<String>,
-    pub no_proxy: Option<String>,
+    pub no_proxy_domain: Option<String>,
 }
 
 impl Default for OroClientProxyConfig {
@@ -26,7 +26,7 @@ impl Default for OroClientProxyConfig {
         Self {
             proxy: false,
             proxy_url: None,
-            no_proxy: Some("NO_PROXY".to_string()),
+            no_proxy_domain: Some("NO_PROXY".to_string()),
         }
     }
 }
@@ -43,8 +43,8 @@ impl OroClientProxyConfig {
         self
     }
 
-    pub fn set_no_proxy_url(mut self, no_proxy: impl AsRef<str>) -> Self {
-        self.no_proxy = Some(no_proxy.as_ref().into());
+    pub fn set_no_proxy_domain(mut self, no_proxy_domain: impl AsRef<str>) -> Self {
+        self.no_proxy_domain = Some(no_proxy_domain.as_ref().into());
         self
     }
 }
@@ -97,8 +97,8 @@ impl OroClientBuilder {
         self
     }
 
-    pub fn set_no_proxy(mut self, no_proxy: impl AsRef<str>) -> Self {
-        self.proxy_config.no_proxy = Some(no_proxy.as_ref().into());
+    pub fn set_no_proxy(mut self, no_proxy_domain: impl AsRef<str>) -> Self {
+        self.proxy_config.no_proxy_domain = Some(no_proxy_domain.as_ref().into());
         self
     }
 
@@ -152,7 +152,7 @@ impl OroClientBuilder {
 
 
     fn get_no_proxy(&self) -> Option<NoProxy> {
-        if let Some(ref no_proxy_conf) = self.proxy_config.no_proxy {
+        if let Some(ref no_proxy_conf) = self.proxy_config.no_proxy_domain {
             if no_proxy_conf != "NO_PROXY" || no_proxy_conf != "" {
                 Some(NoProxy::from_string(no_proxy_conf));
             }

--- a/crates/oro-client/src/client.rs
+++ b/crates/oro-client/src/client.rs
@@ -8,10 +8,12 @@ use reqwest::Client;
 #[cfg(not(target_arch = "wasm32"))]
 use reqwest::ClientBuilder;
 #[cfg(not(target_arch = "wasm32"))]
+use reqwest::{NoProxy, Proxy};
+#[cfg(not(target_arch = "wasm32"))]
 use reqwest_middleware::ClientWithMiddleware;
-use reqwest::{Proxy, NoProxy};
 use url::Url;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::OroClientError;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -86,17 +88,20 @@ impl OroClientBuilder {
         self
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn set_proxy(mut self, proxy: bool) -> Self {
         self.proxy_config.proxy = proxy;
         self
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn set_proxy_url(mut self, proxy_url: impl AsRef<str>) -> Self {
         self.proxy_config.proxy_url = Some(proxy_url.as_ref().into());
         self.proxy_config.proxy = true;
         self
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn set_no_proxy(mut self, no_proxy_domain: impl AsRef<str>) -> Self {
         self.proxy_config.no_proxy_domain = Some(no_proxy_domain.as_ref().into());
         self
@@ -150,7 +155,7 @@ impl OroClientBuilder {
         }
     }
 
-
+    #[cfg(not(target_arch = "wasm32"))]
     fn get_no_proxy(&self) -> Option<NoProxy> {
         if let Some(ref no_proxy_conf) = self.proxy_config.no_proxy_domain {
             if no_proxy_conf != "NO_PROXY" || no_proxy_conf != "" {
@@ -161,6 +166,7 @@ impl OroClientBuilder {
         NoProxy::from_env().or(None)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn set_request_proxy(&self, url: &str) -> Result<Proxy, OroClientError> {
         let url_info = Url::parse(url).expect("Fail to parse proxy url");
         let username = url_info.username();

--- a/crates/oro-client/src/lib.rs
+++ b/crates/oro-client/src/lib.rs
@@ -5,5 +5,5 @@ mod client;
 mod error;
 
 pub use api::packument;
-pub use client::{OroClient, OroClientBuilder, OroClientProxyConfig};
+pub use client::{OroClient, OroClientBuilder};
 pub use error::OroClientError;

--- a/crates/oro-client/src/lib.rs
+++ b/crates/oro-client/src/lib.rs
@@ -5,5 +5,5 @@ mod client;
 mod error;
 
 pub use api::packument;
-pub use client::{OroClient, OroClientBuilder};
+pub use client::{OroClient, OroClientBuilder, OroClientProxyConfig};
 pub use error::OroClientError;

--- a/src/apply_args.rs
+++ b/src/apply_args.rs
@@ -104,6 +104,15 @@ pub struct ApplyArgs {
 
     #[arg(from_global)]
     pub emoji: bool,
+
+    #[arg(from_global)]
+    pub proxy: bool,
+
+    #[arg(from_global)]
+    pub proxy_url: Option<String>,
+
+    #[arg(from_global)]
+    pub no_proxy: Option<String>,
 }
 
 impl ApplyArgs {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,15 +278,14 @@ pub struct Orogene {
     )]
     proxy_url: Option<String>,
 
-    /// Domain extensions that should bypass any proxies.
+    /// Use commas to separate multiple entries, e.g. `.host1.com,.host2.com`.
     ///
-    /// using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through
-    /// environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
+    /// Can also be configured through the `NO_PROXY` environment variable, like `NO_PROXY=.host1.com`.
     #[arg(
         help_heading = "Global Options",
         global = true,
         long = "no-proxy-domain",
-        default_value = "NO_PROXY"
+        default_value = None
     )]
     no_proxy_domain: Option<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,39 @@ pub struct Orogene {
 
     #[command(subcommand)]
     subcommand: OroCmd,
+
+    /// Use proxy to delegate the network.
+    /// 
+    /// Proxy is opt-in, it uses for outgoing http/https request. 
+    /// If enabled, should set proxy-url too.
+    #[arg(
+        help_heading = "Global Options",
+        global = true,
+        long,
+        default_value_t = false,
+    )]
+    proxy: bool,
+
+    /// A proxy to use for outgoing http requests. 
+    #[arg(
+        help_heading = "Global Options",
+        global = true,
+        long = "proxy-url",
+        default_value = None
+    )]
+    proxy_url: Option<String>,
+
+    /// Domain extensions that should bypass any proxies.
+    /// 
+    /// using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through
+    /// environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
+    #[arg(
+        help_heading = "Global Options",
+        global = true,
+        long = "no-proxy-domain",
+        default_value = "NO_PROXY"
+    )]
+    no_proxy_domain: Option<String>,
 }
 
 impl Orogene {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,18 +258,18 @@ pub struct Orogene {
     subcommand: OroCmd,
 
     /// Use proxy to delegate the network.
-    /// 
-    /// Proxy is opt-in, it uses for outgoing http/https request. 
+    ///
+    /// Proxy is opt-in, it uses for outgoing http/https request.
     /// If enabled, should set proxy-url too.
     #[arg(
         help_heading = "Global Options",
         global = true,
         long,
-        default_value_t = false,
+        default_value_t = false
     )]
     proxy: bool,
 
-    /// A proxy to use for outgoing http requests. 
+    /// A proxy to use for outgoing http requests.
     #[arg(
         help_heading = "Global Options",
         global = true,
@@ -279,7 +279,7 @@ pub struct Orogene {
     proxy_url: Option<String>,
 
     /// Domain extensions that should bypass any proxies.
-    /// 
+    ///
     /// using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through
     /// environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
     #[arg(

--- a/tests/snapshots/help__add.snap
+++ b/tests/snapshots/help__add.snap
@@ -204,10 +204,8 @@ A proxy to use for outgoing http requests
 
 #### `--no-proxy-domain <NO_PROXY_DOMAIN>`
 
-Domain extensions that should bypass any proxies.
+Use commas to separate multiple entries, e.g. `.host1.com,.host2.com`.
 
-using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
-
-\[default: NO_PROXY]
+Can also be configured through the `NO_PROXY` environment variable, like `NO_PROXY=.host1.com`.
 
 

--- a/tests/snapshots/help__add.snap
+++ b/tests/snapshots/help__add.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/help.rs
+assertion_line: 7
 expression: "sub_md(\"add\")"
 ---
 stderr:
@@ -190,5 +191,23 @@ Telemetry for Orogene is opt-in, anonymous, and is used to help the team improve
 #### `--sentry-dsn <SENTRY_DSN>`
 
 Sentry DSN (access token) where telemetry will be sent (if enabled)
+
+#### `--proxy`
+
+Use proxy to delegate the network.
+
+Proxy is opt-in, it uses for outgoing http/https request. If enabled, should set proxy-url too.
+
+#### `--proxy-url <PROXY_URL>`
+
+A proxy to use for outgoing http requests
+
+#### `--no-proxy-domain <NO_PROXY_DOMAIN>`
+
+Domain extensions that should bypass any proxies.
+
+using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
+
+\[default: NO_PROXY]
 
 

--- a/tests/snapshots/help__apply.snap
+++ b/tests/snapshots/help__apply.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/help.rs
+assertion_line: 12
 expression: "sub_md(\"apply\")"
 ---
 stderr:
@@ -170,5 +171,23 @@ Telemetry for Orogene is opt-in, anonymous, and is used to help the team improve
 #### `--sentry-dsn <SENTRY_DSN>`
 
 Sentry DSN (access token) where telemetry will be sent (if enabled)
+
+#### `--proxy`
+
+Use proxy to delegate the network.
+
+Proxy is opt-in, it uses for outgoing http/https request. If enabled, should set proxy-url too.
+
+#### `--proxy-url <PROXY_URL>`
+
+A proxy to use for outgoing http requests
+
+#### `--no-proxy-domain <NO_PROXY_DOMAIN>`
+
+Domain extensions that should bypass any proxies.
+
+using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
+
+\[default: NO_PROXY]
 
 

--- a/tests/snapshots/help__apply.snap
+++ b/tests/snapshots/help__apply.snap
@@ -184,10 +184,8 @@ A proxy to use for outgoing http requests
 
 #### `--no-proxy-domain <NO_PROXY_DOMAIN>`
 
-Domain extensions that should bypass any proxies.
+Use commas to separate multiple entries, e.g. `.host1.com,.host2.com`.
 
-using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
-
-\[default: NO_PROXY]
+Can also be configured through the `NO_PROXY` environment variable, like `NO_PROXY=.host1.com`.
 
 

--- a/tests/snapshots/help__ping.snap
+++ b/tests/snapshots/help__ping.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/help.rs
+assertion_line: 17
 expression: "sub_md(\"ping\")"
 ---
 stderr:
@@ -104,5 +105,23 @@ Telemetry for Orogene is opt-in, anonymous, and is used to help the team improve
 #### `--sentry-dsn <SENTRY_DSN>`
 
 Sentry DSN (access token) where telemetry will be sent (if enabled)
+
+#### `--proxy`
+
+Use proxy to delegate the network.
+
+Proxy is opt-in, it uses for outgoing http/https request. If enabled, should set proxy-url too.
+
+#### `--proxy-url <PROXY_URL>`
+
+A proxy to use for outgoing http requests
+
+#### `--no-proxy-domain <NO_PROXY_DOMAIN>`
+
+Domain extensions that should bypass any proxies.
+
+using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
+
+\[default: NO_PROXY]
 
 

--- a/tests/snapshots/help__ping.snap
+++ b/tests/snapshots/help__ping.snap
@@ -118,10 +118,8 @@ A proxy to use for outgoing http requests
 
 #### `--no-proxy-domain <NO_PROXY_DOMAIN>`
 
-Domain extensions that should bypass any proxies.
+Use commas to separate multiple entries, e.g. `.host1.com,.host2.com`.
 
-using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
-
-\[default: NO_PROXY]
+Can also be configured through the `NO_PROXY` environment variable, like `NO_PROXY=.host1.com`.
 
 

--- a/tests/snapshots/help__reapply.snap
+++ b/tests/snapshots/help__reapply.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/help.rs
+assertion_line: 22
 expression: "sub_md(\"reapply\")"
 ---
 stderr:
@@ -179,10 +180,8 @@ A proxy to use for outgoing http requests
 
 #### `--no-proxy-domain <NO_PROXY_DOMAIN>`
 
-Domain extensions that should bypass any proxies.
+Use commas to separate multiple entries, e.g. `.host1.com,.host2.com`.
 
-using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
-
-\[default: NO_PROXY]
+Can also be configured through the `NO_PROXY` environment variable, like `NO_PROXY=.host1.com`.
 
 

--- a/tests/snapshots/help__reapply.snap
+++ b/tests/snapshots/help__reapply.snap
@@ -167,4 +167,22 @@ Telemetry for Orogene is opt-in, anonymous, and is used to help the team improve
 
 Sentry DSN (access token) where telemetry will be sent (if enabled)
 
+#### `--proxy`
+
+Use proxy to delegate the network.
+
+Proxy is opt-in, it uses for outgoing http/https request. If enabled, should set proxy-url too.
+
+#### `--proxy-url <PROXY_URL>`
+
+A proxy to use for outgoing http requests
+
+#### `--no-proxy-domain <NO_PROXY_DOMAIN>`
+
+Domain extensions that should bypass any proxies.
+
+using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
+
+\[default: NO_PROXY]
+
 

--- a/tests/snapshots/help__remove.snap
+++ b/tests/snapshots/help__remove.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/help.rs
+assertion_line: 27
 expression: "sub_md(\"remove\")"
 ---
 stderr:
@@ -187,10 +188,8 @@ A proxy to use for outgoing http requests
 
 #### `--no-proxy-domain <NO_PROXY_DOMAIN>`
 
-Domain extensions that should bypass any proxies.
+Use commas to separate multiple entries, e.g. `.host1.com,.host2.com`.
 
-using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
-
-\[default: NO_PROXY]
+Can also be configured through the `NO_PROXY` environment variable, like `NO_PROXY=.host1.com`.
 
 

--- a/tests/snapshots/help__remove.snap
+++ b/tests/snapshots/help__remove.snap
@@ -175,4 +175,22 @@ Telemetry for Orogene is opt-in, anonymous, and is used to help the team improve
 
 Sentry DSN (access token) where telemetry will be sent (if enabled)
 
+#### `--proxy`
+
+Use proxy to delegate the network.
+
+Proxy is opt-in, it uses for outgoing http/https request. If enabled, should set proxy-url too.
+
+#### `--proxy-url <PROXY_URL>`
+
+A proxy to use for outgoing http requests
+
+#### `--no-proxy-domain <NO_PROXY_DOMAIN>`
+
+Domain extensions that should bypass any proxies.
+
+using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
+
+\[default: NO_PROXY]
+
 

--- a/tests/snapshots/help__view.snap
+++ b/tests/snapshots/help__view.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/help.rs
+assertion_line: 32
 expression: "sub_md(\"view\")"
 ---
 stderr:
@@ -131,10 +132,8 @@ A proxy to use for outgoing http requests
 
 #### `--no-proxy-domain <NO_PROXY_DOMAIN>`
 
-Domain extensions that should bypass any proxies.
+Use commas to separate multiple entries, e.g. `.host1.com,.host2.com`.
 
-using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
-
-\[default: NO_PROXY]
+Can also be configured through the `NO_PROXY` environment variable, like `NO_PROXY=.host1.com`.
 
 

--- a/tests/snapshots/help__view.snap
+++ b/tests/snapshots/help__view.snap
@@ -119,4 +119,22 @@ Telemetry for Orogene is opt-in, anonymous, and is used to help the team improve
 
 Sentry DSN (access token) where telemetry will be sent (if enabled)
 
+#### `--proxy`
+
+Use proxy to delegate the network.
+
+Proxy is opt-in, it uses for outgoing http/https request. If enabled, should set proxy-url too.
+
+#### `--proxy-url <PROXY_URL>`
+
+A proxy to use for outgoing http requests
+
+#### `--no-proxy-domain <NO_PROXY_DOMAIN>`
+
+Domain extensions that should bypass any proxies.
+
+using `--no-proxy-domain` to set. For example: ".host1.com, ".host2.com" ，or through environment variable "NO_PROXY" to setsuch as "NO_PROXY=.host1.com, ".host2.com"
+
+\[default: NO_PROXY]
+
 


### PR DESCRIPTION
This pr is following [#223](https://github.com/orogene/orogene/issues/223) to support proxy setting. It adds three config:

* `--proxy` is to set the proxy is true;
* `--proxy-url` is to define the proxy url;
* `--no-proxy` is to define the request should bypass or close the proxy.

