### PR TITLE
fix: com.apple.application-identifier needs a period

### DIFF
--- a/crates/alabaster/src/macos/alabaster-swift/Sources/alabaster-swift/AlabasterSwift.entitlements
+++ b/crates/alabaster/src/macos/alabaster-swift/Sources/alabaster-swift/AlabasterSwift.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.application-identifier</key>
-	<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>$(AppIdentifierPrefix).$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>


### PR DESCRIPTION
There are two issues:
1. the value for the `application-identifier` entitlement is missing a period
2. the `oro` binary is not signed with the entitlements file


after applying the PR, run:

```shell
# rebuild
cargo build

# sign with entitlements
codesign -s - -f --entitlements crates/alabaster/src/macos/alabaster-swift/Sources/alabaster-swift/AlabasterSwift.entitlements target/debug/oro
target/debug/oro: replacing existing signature

# validate signature
codesign -d --entitlements - --xml target/debug/oro
Executable=/Users/jan/Work/rust/orogene/target/debug/oro
<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.application-identifier</key><string>$(AppIdentifierPrefix).$(PRODUCT_BUNDLE_IDENTIFIER)</string><key>com.apple.security.app-sandbox</key><true/><key>com.apple.security.application-groups</key><array></array></dict></plist>

# now
> ./target/debug/oro mount
Trace/BPT trap: 5
```

note that `cargo run mount` will re-build and re-sign the binary to before our change, so this should really be part of the build process.

Now the new error is also not great, but a step forward. 

- This could be some more MacOS weirdness, but e.g. none of the remediations https://apple.stackexchange.com/questions/113379/how-to-debug-trace-bpt-trap-5 helped
- this could be still bad code signing, I have not found a pointer to this yet
- this could be a genuine issue in the rust, swift or bridge code (c.f. https://developer.apple.com/forums/thread/705740)
