### PR TITLE
feat: conditional sentry reporting feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ is-terminal = { workspace = true }
 kdl = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 rand = { workspace = true, default_features = false }
-sentry = { workspace = true }
+sentry = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 supports-unicode = { workspace = true }
@@ -72,6 +72,10 @@ edition = "2021"
 repository = "https://github.com/orogene/orogene"
 homepage = "https://orogene.dev"
 rust-version = "1.67.1"
+
+[features]
+default = ["error-reporting"]
+error-reporting = ["sentry"]
 
 [workspace.dependencies]
 anyhow = "1.0.75"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,13 +86,12 @@
 //! [our contribution guide]: https://orogene.dev/CONTRIBUTING/
 //! [Apache 2.0 License]: https://github.com/orogene/orogene/blob/main/LICENSE
 
+#[cfg(feature = "error-reporting")]
+use std::{borrow::Cow, panic::PanicInfo, sync::Arc};
 use std::{
-    borrow::Cow,
     collections::VecDeque,
     ffi::OsString,
-    panic::PanicInfo,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -598,6 +597,7 @@ impl Orogene {
             .into_diagnostic()
     }
 
+    #[cfg(feature = "error-reporting")]
     fn setup_telemetry(
         &self,
         log_file: Option<PathBuf>,
@@ -700,6 +700,7 @@ impl Orogene {
             .map(|c| c.join("_logs").join(log_file_name()));
         let _logging_guard = oro.setup_logging(log_file.as_deref())?;
         oro.first_time_setup()?;
+        #[cfg(feature = "error-reporting")]
         let _telemetry_guard = oro.setup_telemetry(log_file.clone())?;
         let do_term_progress = !oro.quiet && oro.progress;
         if do_term_progress {
@@ -723,6 +724,7 @@ impl Orogene {
                 tracing::debug!("{e:?}");
                 if let Some(log_file) = log_file.as_deref() {
                     tracing::warn!("A debug log was written to {}", log_file.display());
+                    #[cfg(feature = "error-reporting")]
                     sentry::configure_scope(|s| {
                         s.add_attachment(sentry::protocol::Attachment {
                             filename: log_file
@@ -735,7 +737,9 @@ impl Orogene {
                         });
                     });
                 }
+                #[cfg(feature = "error-reporting")]
                 let dyn_err: &dyn std::error::Error = e.as_ref();
+                #[cfg(feature = "error-reporting")]
                 sentry::capture_error(dyn_err);
                 e
             })?;


### PR DESCRIPTION
Adds a simple feature flag, `error-reporting`, which toggles error reporting to Sentry. We have toggled this off for now so as not to flood your error reports from our usage downstream. The feature is defaulted to on so that nothing needs to change on Orogene's side w.r.t. release or build process.