### PR TITLE
feat: add optional `mimalloc` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +1911,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2342,6 +2361,7 @@ dependencies = [
  "is_ci",
  "kdl",
  "miette",
+ "mimalloc",
  "nassun",
  "node-maintainer",
  "oro-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ tag = true
 upgrade-guid = "C5FC7FE8-A6AB-4897-8B26-01220D1C3FAD"
 path-guid = "D7A7057F-9CE2-4FB0-A0CF-1293469361C5"
 
+[features]
+mimalloc = ["dep:mimalloc"]
+
 [dependencies]
 # Workspace Deps
 nassun = { version = "=0.3.34", path = "./crates/nassun" }
@@ -49,6 +52,7 @@ is_ci = { workspace = true }
 is-terminal = { workspace = true }
 kdl = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
+mimalloc = { workspace = true, optional = true }
 rand = { workspace = true, default_features = false }
 sentry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -111,6 +115,7 @@ junction = "1.0.0"
 kdl = "5.0.0-alpha.1"
 maplit = "1.0.2"
 miette = "5.8.0"
+mimalloc = "0.1.43"
 mockito = "1.0.0"
 node-semver = "2.1.0"
 nom = "7.1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 use miette::Result;
 use orogene::Orogene;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[async_std::main]
 async fn main() -> Result<()> {
     Ok(Orogene::load().await?)


### PR DESCRIPTION
Adds an optional feature to use `mimalloc` as the default allocator.

```
> No cache, no node_modules, no lockfile

 INFO 🔍 Resolved 3 packages in 0.423s.
 INFO 🧹 Pruned 0 packages in 0s.
 INFO 📦 Extracted 2 packages in 0.225s.
 INFO 🏃 Ran lifecycle scripts in 0.001s.
 INFO 📝 Wrote lockfile to package-lock.kdl.
 INFO 🎉 Applied node_modules/ in 0.661s. Fasterthanlime-fame is but a hack away!

../target/release/oro apply  0.17s user 0.19s system 51% cpu 0.707 total

> No node_modules, no lockfile

➜  tmp git:(feat/mimalloc) ✗ rm -fr node_modules package-lock.kdl
➜  tmp git:(feat/mimalloc) ✗ time ../target/release/oro apply

 INFO 🔍 Resolved 3 packages in 0.101s.
 INFO 🧹 Pruned 0 packages in 0s.
 INFO 📦 Extracted 2 packages in 0.013s.
 INFO 🏃 Ran lifecycle scripts in 0s.
 INFO 📝 Wrote lockfile to package-lock.kdl.
 INFO 🎉 Applied node_modules/ in 0.128s. May the source be with you.

../target/release/oro apply  0.05s user 0.13s system 107% cpu 0.175 total

> No node_modules

➜  tmp git:(feat/mimalloc) ✗ rm -fr node_modules
➜  tmp git:(feat/mimalloc) ✗ time ../target/release/oro apply

 INFO 🔍 Resolved 3 packages in 0.001s.
 INFO 🧹 Pruned 0 packages in 0s.
 INFO 📦 Extracted 2 packages in 0.015s.
 INFO 🏃 Ran lifecycle scripts in 0s.
 INFO 📝 Wrote lockfile to package-lock.kdl.
 INFO 🎉 Applied node_modules/ in 0.031s. Hack and be merry!

../target/release/oro apply  0.03s user 0.06s system 116% cpu 0.076 total

> Fully warmed

➜  tmp git:(feat/mimalloc) ✗ time ../target/release/oro apply

 INFO 🔍 Resolved 3 packages in 0.001s.
 INFO 🧹 Pruned 0 packages in 0.009s.
 INFO 📦 Extracted 0 packages in 0.001s.
 INFO 🏃 Ran lifecycle scripts in 0s.
 INFO 📝 Wrote lockfile to package-lock.kdl.
 INFO 🎉 Applied node_modules/ in 0.028s. Fasterthanlime-fame is but a hack away!

../target/release/oro apply  0.02s user 0.07s system 114% cpu 0.076 total
```