### PR TITLE
feat: add experimental `simd-json` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.10",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +49,12 @@ checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -1060,6 +1079,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,12 +1344,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.1",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1329,6 +1367,10 @@ name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+dependencies = [
+ "ahash 0.8.11",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1994,6 +2036,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.4.5",
  "serde_json",
+ "simd-json",
  "ssri",
  "tar",
  "tempfile",
@@ -2758,6 +2801,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53313ec9f12686aeeffb43462c3ac77aa25f590a5f630eb2cde0de59417b29c7"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2566c4bf6845f2c2e83b27043c3f5dfcd5ba8f2937d6c00dc009bfb51a079dc4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "reflink-copy"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,6 +3452,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd-json"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
+dependencies = [
+ "ahash 0.8.11",
+ "getrandom 0.2.10",
+ "halfbrown",
+ "once_cell",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,7 +3559,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
- "float-cmp",
+ "float-cmp 0.9.0",
 ]
 
 [[package]]
@@ -3522,7 +3602,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "639abcebc15fdc2df179f37d6f5463d660c1c79cd552c12343a4600827a04bce"
 dependencies = [
- "float-cmp",
+ "float-cmp 0.9.0",
  "rgb",
 ]
 
@@ -4175,6 +4255,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
+name = "value-trait"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
+dependencies = [
+ "float-cmp 0.10.0",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,6 +4775,26 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ repository = "https://github.com/orogene/orogene"
 homepage = "https://orogene.dev"
 rust-version = "1.67.1"
 
+[features]
+experimental-simdjson = ["nassun/experimental-simdjson"]
+
 [workspace.dependencies]
 anyhow = "1.0.75"
 async-compression = "0.3.5"
@@ -134,6 +137,7 @@ sentry = "0.31.0"
 serde = "1.0.152"
 serde_json = "1.0.93"
 serde-wasm-bindgen = "0.4.5"
+simd-json = "0.14.3"
 ssri = "9.0.0"
 supports-unicode = "2.0.0"
 syn = "1.0.33"

--- a/crates/nassun/Cargo.toml
+++ b/crates/nassun/Cargo.toml
@@ -11,6 +11,9 @@ repository.workspace = true
 homepage.workspace = true
 rust-version.workspace = true
 
+[features]
+experimental-simdjson = ["dep:simd-json"]
+
 [dependencies]
 oro-common = { version = "=0.3.34", path = "../oro-common" }
 oro-client = { version = "=0.3.34", path = "../oro-client" }
@@ -31,6 +34,7 @@ node-semver = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+simd-json = { workspace = true, features = ["serde_impl", "known-key"], optional = true }
 ssri = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/nassun/src/fetch/dir.rs
+++ b/crates/nassun/src/fetch/dir.rs
@@ -27,6 +27,7 @@ impl DirFetcher {
 }
 
 impl DirFetcher {
+    #[cfg(not(feature = "experimental-simd-json"))]
     pub(crate) async fn corgi_manifest(&self, path: &Path) -> Result<Manifest> {
         let pkg_path = path.join("package.json");
         let json = async_std::fs::read(&pkg_path)
@@ -36,6 +37,8 @@ impl DirFetcher {
             serde_json::from_slice(&json[..]).map_err(NassunError::SerdeError)?;
         Ok(Manifest::Corgi(Box::new(pkgjson)))
     }
+
+    #[cfg(not(feature = "experimental-simd-json"))]
     pub(crate) async fn manifest(&self, path: &Path) -> Result<Manifest> {
         let pkg_path = path.join("package.json");
         let json = async_std::fs::read(&pkg_path)
@@ -43,6 +46,28 @@ impl DirFetcher {
             .map_err(|err| NassunError::DirReadError(err, pkg_path))?;
         let pkgjson: OroManifest =
             serde_json::from_slice(&json[..]).map_err(NassunError::SerdeError)?;
+        Ok(Manifest::FullFat(Box::new(pkgjson)))
+    }
+
+    #[cfg(feature = "experimental-simd-json")]
+    pub(crate) async fn corgi_manifest(&self, path: &Path) -> Result<Manifest> {
+        let pkg_path = path.join("package.json");
+        let mut json = async_std::fs::read(&pkg_path)
+            .await
+            .map_err(|err| NassunError::DirReadError(err, pkg_path))?;
+        let pkgjson: CorgiManifest =
+            simd_json::from_slice(&mut json[..]).map_err(NassunError::SerdeSimdError)?;
+        Ok(Manifest::Corgi(Box::new(pkgjson)))
+    }
+
+    #[cfg(feature = "experimental-simd-json")]
+    pub(crate) async fn manifest(&self, path: &Path) -> Result<Manifest> {
+        let pkg_path = path.join("package.json");
+        let mut json = async_std::fs::read(&pkg_path)
+            .await
+            .map_err(|err| NassunError::DirReadError(err, pkg_path))?;
+        let pkgjson: OroManifest =
+            simd_json::from_slice(&mut json[..]).map_err(NassunError::SerdeSimdError)?;
         Ok(Manifest::FullFat(Box::new(pkgjson)))
     }
 


### PR DESCRIPTION
Functionality is guarded by the `experimental-simdjson` feature flag. I'm not 100% sure the crate is actually in use properly yet, and I haven't benchmarked, so this is marked initially as a draft.